### PR TITLE
[Feat][정의준] Airflow 일일 통계 dags 추가, git ignore 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -489,3 +489,6 @@ junit/
 Recbole/dataset/train_data/train_data.item
 interaction_model/LightGCN_64
 Airflow/BaseLine/airflow.cfg
+Airflow/BaseLine/logs
+Airflow/BaseLine/airflow.db
+Airflow/BaseLine/airflow-webserver.pid

--- a/Airflow/BaseLine/dags/summary.py
+++ b/Airflow/BaseLine/dags/summary.py
@@ -93,7 +93,7 @@ def load_yesterday_summary():
 with DAG(
         dag_id='daily_summary',
         default_args=default_args,
-        schedule_interval='1 0 * * *',
+        schedule_interval='1 9 * * *',
         tags=['summary']
 ) as dag:
     python_task = PythonOperator(

--- a/Airflow/BaseLine/dags/summary.py
+++ b/Airflow/BaseLine/dags/summary.py
@@ -1,0 +1,104 @@
+import os
+import pandas as pd
+from pathlib import Path
+from environ import Env
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from sqlalchemy import create_engine
+from datetime import date,timedelta,datetime
+import mysql.connector
+import json
+
+default_args = {
+    'owner': 'cwj',
+    'depends_on_past': False,  
+    'start_date': datetime(2023, 2, 2),
+    'retires': 1,  
+    'retry_delay': timedelta(minutes=5) 
+    # 'priority_weight': 10 
+    # 'end_date': datetime(2022, 4, 24) 
+    # 'execution_timeout': timedelta(seconds=300),
+    # 'on_failure_callback': some_function
+    # 'on_success_callback': some_other_function
+    # 'on_retry_callback': another_function
+}
+
+def load_yesterday_summary():
+    BASE_DIR = Path(os.curdir).resolve()
+    env = Env()
+    env_path = BASE_DIR / "level3_productserving-level3-recsys-08/django/.env"
+    if env_path.exists():
+        with env_path.open("rt",encoding="utf8") as f:
+            env.read_env(f,overwite = True)
+
+    dbname = env.get_value("GCPDB_NAME")
+    user = env.get_value("GCPDB_USER")
+    pw = env.get_value("GCPDB_PASSWORD")
+    host = env.get_value("GCPDB_HOST")
+
+    engine = create_engine(f"mysql+mysqldb://{user}:{pw}@{host}:3306/{dbname}")
+
+    yesterday = date.today()-timedelta(1)
+
+    df = pd.read_sql_query(f"select * from test_rec_tmpuser WHERE DATE(create_time)='{str(yesterday)}'",engine)
+
+    MBTI_summary = df.value_counts("MBTI").to_dict()
+
+    prefer_summary = {}
+    for p in df['prefer_movie_id']:
+        if p != None:
+            p = json.loads(p)
+            for mid in list(p):
+                try :
+                    prefer_summary[mid] +=1
+                except :
+                    prefer_summary[mid] = 1
+
+    recommend_summary = {}
+    for r in df['recommended_character_id']:
+        if r != None:
+            r = json.loads(r)
+            for mid in list(r):
+                try :
+                    recommend_summary[mid] +=1
+                except :
+                    recommend_summary[mid] = 1
+
+    prefer_summary = dict(sorted(prefer_summary.items(),key = lambda x: -x[1]))
+    recommend_summary = dict(sorted(recommend_summary.items(),key = lambda x: -x[1]))
+
+    conn = mysql.connector.connect(
+        host=host,
+        user=user,
+        password=pw,
+        db=dbname,
+        charset='utf8'
+    )
+
+    datetime_value = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+
+    cursor = conn.cursor()
+
+    query = "INSERT INTO summary (MBTI_summary, prefer_summary, character_summary, create_time) VALUES (%s, %s, %s, %s)"
+
+    cursor.execute(query, (json.dumps(MBTI_summary),json.dumps(prefer_summary),json.dumps(recommend_summary),datetime_value))
+
+    conn.commit()
+
+    cursor.close()
+    conn.close()
+    
+
+
+with DAG(
+        dag_id='daily_summary',
+        default_args=default_args,
+        schedule_interval='1 0 * * *',
+        tags=['summary']
+) as dag:
+    python_task = PythonOperator(
+        task_id='yesterday_summary',
+        python_callable=load_yesterday_summary
+    )
+
+    python_task


### PR DESCRIPTION
## 📍 개요

- 매일 0시 1분에 django DB에서 전날 기록을 가져옵니다
- 유저의 MBTI, 선호하는 영화, 추천받은 캐릭터의 카운트를 세어 django - summary TABLE에 저장합니다.

## 🔑 Key Changes

- dags - summary.py 작성
- .gitignore에 로컬 airflow db 관련 파일 추가

## ✅ To Reviewers

- DB의 column은 이렇게하면 될까요??
![image](https://user-images.githubusercontent.com/71438046/216526550-d13fc755-291a-49a4-aa9f-26e85f4f69d1.png)


